### PR TITLE
Switch nest translator to user firebase submodule.

### DIFF
--- a/Helpers/OpenT2T-Wink-Helper/js/index.js
+++ b/Helpers/OpenT2T-Wink-Helper/js/index.js
@@ -18,7 +18,6 @@ module.exports =
        apiPath = '/' + apiEndpoint + '/' + deviceID;
        console.log("Api path is " + apiPath)
        accessToken = token; //the specific token
-        
    },
  
    sendDesiredStateCommand: function(apiField,value) 

--- a/org.OpenT2T.Sample.SuperPopular.Thermostat/Wink Thermostat/js/thingTranslator.js
+++ b/org.OpenT2T.Sample.SuperPopular.Thermostat/Wink Thermostat/js/thingTranslator.js
@@ -1,7 +1,6 @@
 'use strict';
-
-var https = require('https');
-var wh = require("opent2t-translator-helper-wink"); //link locally for now
+var Firebase = require('firebase');
+var q = require('q');
 
 // logs device state
 function logDeviceState(device) {
@@ -13,18 +12,6 @@ function logDeviceState(device) {
     }
 };
 
-var deviceId, accessToken;
-
-function logPromise(p) {
-    return p.then(result => {
-        console.log(result);
-        return result;
-    }).catch(error => {
-        console.log(error.message);
-        throw error;
-    });
-}
-
 function validateArgumentType(arg, argName, expectedType) {
     if (typeof arg === 'undefined') {
         throw new Error('Missing argument: ' + argName + '. ' +
@@ -35,83 +22,160 @@ function validateArgumentType(arg, argName, expectedType) {
     }
 }
 
-var device;
-var props;
-
 // module exports, implementing the schema
 module.exports = {
 
     initDevice: function (dev) {
+        var myThis = this;
+        this.device = dev;
         console.log('Initializing device.');
 
-        device = dev;
-        validateArgumentType(device, 'device', 'object');
-        validateArgumentType(device.props, 'device.props', 'string');
+        myThis.firebaseRef = new Firebase("https://developer-api.nest.com");
+        myThis.data = null;
+        myThis.fahrenheit = false;
 
-        props = JSON.parse(device.props);
+        validateArgumentType(myThis.device, 'device', 'object');
+        validateArgumentType(myThis.device.props, 'device.props', 'string');
+
+        var props = JSON.parse(myThis.device.props);
         validateArgumentType(props.access_token, 'device.props.access_token', 'string');
         validateArgumentType(props.id, 'device.props.id', 'string');
 
-        deviceId = props.id;
-        accessToken = props.access_token;
+        myThis.nestThermostat = myThis.firebaseRef.child("devices/thermostats/" + props.id);
 
-        //use the winkHub device and initialize
-        wh.initWinkApi("thermostats", deviceId, accessToken);
-        console.log('Javascript and Wink Helper initialized');
-        logDeviceState(device);
-    },
+        logDeviceState(this.device);
 
-    isTurnedOn: function () {
-        console.log('isTurnedOn called.');
-        return logPromise(wh.getValueOfDesiredState('powered', true));
-    },
-
-    turnOn: function () {
-        console.log('turnOn called.');
-        return logPromise(wh.sendDesiredStateCommand('powered', true));
-    },
-
-    turnOff: function () {
-        console.log('turnOff called.');
-        return logPromise(wh.sendDesiredStateCommand('powered', false));
-    },
-
-    getCurrentTemperature: function () {
-        console.log('getting current temp');
-        return logPromise(wh.getLastReading('temperature'));
-    },
-
-    getCoolingSetpoint: function () {
-        console.log('getting cooling point');
-        return logPromise(wh.getValueOfDesiredState('max_set_point'));
-    },
-
-    getHeatingSetpoint: function () {
-        console.log('getting heating point');
-        return logPromise(wh.getValueOfDesiredState('min_set_point'));
-    },
-
-    getMode: function () {
-        console.log('getting mode.');
-        return logPromise(wh.getValueOfDesiredState('mode'));
-    },
-
-    setMode: function (value) {
-        console.log("Trying to set Mode");
-        return logPromise(wh.sendDesiredStateCommand('mode', value));
-    },
-
-    setHeatingSetpoint: function (temp) {
-        console.log("Changing Heating Setpoint");
-        return logPromise(wh.sendDesiredStateCommand('min_set_point', temp));
-    },
-    setCoolingSetpoint: function (temp) {
-        console.log("Changing Cooling Setpoint");
-        return logPromise(wh.sendDesiredStateCommand('max_set_point', temp));
+        var deferred = q.defer();   // Take a deferral
+        // Authenticate users with a custom authentication token
+        myThis.nestThermostat.authWithCustomToken(props.access_token, (error, authData) => {
+            if (error) {
+                console.log("Login Failed!", error);
+                deferred.reject(error);
+            } else {
+                console.log("Successfully authenticated with developer-api.nest.com: " + JSON.stringify(authData));
+                myThis.update().then((data) => {
+                    deferred.resolve(data);
+                }, error => {
+                    deferred.reject(error);
+                });
+                console.log('Initialized.');
+            }
+        });
+        return deferred.promise; // return the promise
     },
 
     disconnect: function () {
         console.log('disconnect called.');
-        logDeviceState(device);
+        logDeviceState(this.device);
+    },
+
+    // update the local cache of device properties
+    update: function () {
+        var myThis = this;
+        var deferred = q.defer();   // Take a deferral
+        myThis.nestThermostat.once('value', result => {
+            var data = result.val();
+            myThis.data = data; // this is a map of property values
+            console.log("thermostat settings=" + JSON.stringify(data));
+            deferred.resolve(data);
+        }, error => {
+            console.log("Reading thermostat value failed: " + error.message);
+            deferred.reject(error);
+        });
+        return deferred.promise; // return the promise
+    },
+
+    useFahrenheit: function (flag) {
+        this.fahrenheit = flag;
+    },
+
+    getProperties: function () {
+        return this.data;
+    },
+
+    setProperty: function (name, value) {
+        var myThis = this;
+        var deferred = q.defer();   // Take a deferral  
+        var propertyRef = myThis.nestThermostat.child(name);
+        if (typeof (value) == "number") {
+            // for some reason Nest only takes integer values.
+            value = Math.round(value);
+        }
+
+        propertyRef.set(value, function (error) {
+            if (error) {
+                console.log("Setting " + name + " failed: " + error);
+                deferred.reject(error);
+            } else {
+                console.log("Set " + name + "=" + value + " succeeded");
+                deferred.resolve(name);
+            }
+        });
+        return deferred.promise; // return the promise
+    },
+
+    getProperty: function (name) {
+        var myThis = this;
+        if (myThis.data == null) {
+            throw new Error("Please call update() before reading properties.");
+        }
+        return myThis.data[name];
+    },
+
+    isTurnedOn: function () {
+        return this.getMode() != 'off';
+    },
+
+    // This function sets the hvac_mode to 'heat-cool' so nest will heat or cool
+    // automatically depending on the settings and the current temperature and
+    // your "green" settings that determine how much it energy it can use...
+    turnOnAuto: function () {
+        return this.setMode('heat-cool');
+    },
+
+    turnOff: function () {
+        return this.setMode('off');
+    },
+
+    getAmbientTemperature : function () {
+        var suffix = (this.fahrenheit ? "_f" : "_c");
+        return this.getProperty('ambient_temperature' + suffix);
+    },
+
+    getHeatingSetpoint : function () {
+        var suffix = (this.fahrenheit ? "_f" : "_c");
+        return this.getProperty('target_temperature_high' + suffix);
+    },
+
+    setHeatingSetpoint: function (value) {
+        var suffix = (this.fahrenheit ? "_f" : "_c");
+        return this.setProperty('target_temperature_high' + suffix, value);
+    },
+
+    getCoolingSetpoint : function () {
+        var suffix = (this.fahrenheit ? "_f" : "_c");
+        return this.getProperty('target_temperature_low' + suffix);
+    },
+
+    setCoolingSetpoint : function (value) {
+        var suffix = (this.fahrenheit ? "_f" : "_c");
+        return this.setProperty('target_temperature_low' + suffix, value);
+    },
+
+    getMode : function () {
+        return this.getProperty('hvac_mode');
+    },
+
+    setMode : function (value) {
+        if (this.getProperty['hvac_mode'] != value) {
+            return this.setProperty('hvac_mode', value);
+        }
+        return emptyPromise();
+    },
+
+    getAvailableModes: function (value) {
+        var deferred = q.defer();   // Take a deferral
+        deferred.resolve(['heat', 'cool', 'heat-cool', 'off']);
+        return deferred.promise; // return the promise
     }
-};
+}

--- a/org.OpenT2T.Sample.SuperPopular.Thermostat/org.OpenT2T.Sample.SuperPopular.Thermostat.xml
+++ b/org.OpenT2T.Sample.SuperPopular.Thermostat/org.OpenT2T.Sample.SuperPopular.Thermostat.xml
@@ -12,8 +12,13 @@
     <!-- Gets current status: true(On) / false(Off) -->
     <method name="isTurnedOn"/>
 
+    <!-- sets fahrenheit units instead of celcius -->
+    <method name="useFahrenheit">
+      <arg name="flag" type="b" direction="in" />
+    </method>
+    
     <!-- Get the current ambient temperature -->
-    <method name="getCurrentTemperature">
+    <method name="getAmbientTemperature">
       <arg name="temp" type="d" direction="out" />
     </method>
 
@@ -27,7 +32,7 @@
       <arg name="temp" type="d" direction="out" />
     </method>
   
-   <!-- set the desired cooling temperature (a.k.a. max setpoint) -->
+    <!-- set the desired cooling temperature (a.k.a. max setpoint) -->
     <method name="setCoolingSetpoint">
       <arg name="temp" type="d" direction="in" />
     </method>


### PR DESCRIPTION
Provide useFahrenheit method because it turns out nest loses precision if we don't use the Fahrenheit properties directly.
Cache all the Nest properties fetched in new update method so app can query multiple properties without doing http round trip on each one.
