### PR TITLE
Schema bug fix + ignored file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ logs
 *.log
 testconfig.json
 *.vscode
+
+# Temporary package.json at the root for packaging translators
+/package.json

--- a/org.opent2t.sample.thermostat.superpopular/org.opent2t.sample.thermostat.superpopular.json
+++ b/org.opent2t.sample.thermostat.superpopular/org.opent2t.sample.thermostat.superpopular.json
@@ -29,7 +29,7 @@
   "type": "object",
   "allOf": [
     { "$ref": "oic.core.json#/definitions/oic.core" },
-    { "$ref": "oic.baseResource.json#/definitions/oic.r.baseResource" },
+    { "$ref": "oic.baseResource.json#/definitions/oic.r.baseresource" },
     { "$ref": "#/definitions/org.opent2t.sample.thermostat.superpopular" }
   ]
 }


### PR DESCRIPTION
The JSON schema $ref resolver is case-sensitive, and that behavior can't be easily changed.

The "baseresource" schema name is a little confusing because the filename has an uppercase 'R', but the identifier inside the file "oic.r.baseresource" is all lowercase. References to that need to use the correct casing. Anyone on the team authoring other OCF-style schemas like this one should check to see if this error was copy-pasted.

Also I'm adding a line to .gitignore to ignore the file generated by [the packaging script](https://github.com/openT2T/opent2t-cli/pull/3).