### PR TITLE
Update Wink Lamp translator to add support for dim

### DIFF
--- a/org.opent2t.sample.lamp.superpopular/com.wink.lightbulb/js/tests/test.js
+++ b/org.opent2t.sample.lamp.superpopular/com.wink.lightbulb/js/tests/test.js
@@ -102,12 +102,12 @@ test.serial('PostLampResURI_Set_NameAndDim', t => {
 
             var value = {};
             value['n'] = "opent2t light";
-            value['dim'] = { 'dimmingSetting': 40 };
+            value['dim'] = { 'dimmingSetting': 43 };
 
             return OpenT2T.invokeMethodAsync(translator, 'org.opent2t.sample.lamp.superpopular', 'postLampResURI', [value]);
         }).then((response) => {
             t.is(response.n, "opent2t light");
-            t.is(response.dim.dimmingSetting, 40);
+            t.is(response.dim.dimmingSetting, 43);
 
             console.log('*** response: \n' + JSON.stringify(response, null, 2));
         });

--- a/org.opent2t.sample.lamp.superpopular/com.wink.lightbulb/js/tests/test.js
+++ b/org.opent2t.sample.lamp.superpopular/com.wink.lightbulb/js/tests/test.js
@@ -52,3 +52,64 @@ test.serial('Power', t => {
                 });
         });
 });
+
+// Get the entire Lamp schema object
+test.serial('GetLampResURI', t => {
+
+    return OpenT2T.createTranslatorAsync(translatorPath, 'thingTranslator', config.Device)
+        .then(translator => {
+            // TEST: translator is valid
+            t.is(typeof translator, 'object') && t.truthy(translator);
+
+            return OpenT2T.invokeMethodAsync(translator, 'org.opent2t.sample.lamp.superpopular', 'getLampResURI', []);
+        }).then((response) => {
+            t.not(response.id, undefined);
+            t.is(response.rt, 'org.opent2t.sample.lamp.superpopular');
+            t.not(response.power, undefined);
+            t.not(response.dim, undefined);
+
+            console.log('*** response: \n' + JSON.stringify(response, null, 2));
+        });
+});
+
+
+// Get the entire Lamp schema object
+test.serial('PostLampResURI_Set_Power', t => {
+
+    return OpenT2T.createTranslatorAsync(translatorPath, 'thingTranslator', config.Device)
+        .then(translator => {
+            // TEST: translator is valid
+            t.is(typeof translator, 'object') && t.truthy(translator);
+
+            var value = {};
+            value['power'] = { 'value': true };
+
+            return OpenT2T.invokeMethodAsync(translator, 'org.opent2t.sample.lamp.superpopular', 'postLampResURI', [value]);
+        }).then((response) => {
+            t.truthy(response.power.value);
+
+            console.log('*** response: \n' + JSON.stringify(response, null, 2));
+        });
+});
+
+// Set the name and dimming for the Lamp
+test.serial('PostLampResURI_Set_NameAndDim', t => {
+
+    return OpenT2T.createTranslatorAsync(translatorPath, 'thingTranslator', config.Device)
+        .then(translator => {
+            // TEST: translator is valid
+            t.is(typeof translator, 'object') && t.truthy(translator);
+
+            var value = {};
+            value['n'] = "opent2t light";
+            value['dim'] = { 'dimmingSetting': 40 };
+
+            return OpenT2T.invokeMethodAsync(translator, 'org.opent2t.sample.lamp.superpopular', 'postLampResURI', [value]);
+        }).then((response) => {
+            t.is(response.n, "opent2t light");
+            t.is(response.dim.dimmingSetting, 40);
+
+            console.log('*** response: \n' + JSON.stringify(response, null, 2));
+        });
+});
+

--- a/org.opent2t.sample.lamp.superpopular/com.wink.lightbulb/js/thingTranslator.js
+++ b/org.opent2t.sample.lamp.superpopular/com.wink.lightbulb/js/thingTranslator.js
@@ -36,17 +36,29 @@ class StateReader {
     }
 }
 
+// Helper method to convert Wink's 0.0-1.0 brightness scale to a 0-100 scale
+function scaleBrightnessToDim(brightnessValue) {
+    return Math.floor(brightnessValue * 100);
+}
+
+// Helper method to convert a 0-100 scale to Wink's 0.0-1.0 brightness scale
+function scaleDimToBrightness(dimmingValue) {
+    return dimmingValue / 100;
+}
+
 // Helper method to convert the device schema to the translator schema.
 function deviceSchemaToTranslatorSchema(deviceSchema) {
     var stateReader = new StateReader(deviceSchema.desired_state, deviceSchema.last_reading);
 
     var powered = stateReader.get('powered');
+    var brightness = stateReader.get('brightness');
 
     return {
         id: deviceSchema['object_type'] + '.' + deviceSchema['object_id'],
         n: deviceSchema['name'],
-        rt: 'org.opent2t.sample.thermostat.superpopular',
-        power: { 'value': powered }
+        rt: 'org.opent2t.sample.lamp.superpopular',
+        power: { 'value': powered },
+        dim: { 'dimmingSetting': scaleBrightnessToDim(brightness), 'range': [0, 100] }
     };
 }
 
@@ -63,6 +75,10 @@ function translatorSchemaToDeviceSchema(translatorSchema) {
 
     if (!!translatorSchema.power) {
         desired_state['powered'] = translatorSchema.power.value;
+    }
+
+    if (!!translatorSchema.dim) {
+        desired_state['brightness'] = scaleDimToBrightness(translatorSchema.dim.dimmingSetting);
     }
 
     return result;

--- a/org.opent2t.sample.lamp.superpopular/com.wink.lightbulb/js/thingTranslator.js
+++ b/org.opent2t.sample.lamp.superpopular/com.wink.lightbulb/js/thingTranslator.js
@@ -37,12 +37,12 @@ class StateReader {
 }
 
 // Helper method to convert Wink's 0.0-1.0 brightness scale to a 0-100 scale
-function scaleBrightnessToDim(brightnessValue) {
+function scaleDeviceBrightnessToTranslatorBrightness(brightnessValue) {
     return Math.floor(brightnessValue * 100);
 }
 
 // Helper method to convert a 0-100 scale to Wink's 0.0-1.0 brightness scale
-function scaleDimToBrightness(dimmingValue) {
+function scaleTranslatorBrightnessToDeviceBrightness(dimmingValue) {
     return dimmingValue / 100;
 }
 
@@ -58,7 +58,7 @@ function deviceSchemaToTranslatorSchema(deviceSchema) {
         n: deviceSchema['name'],
         rt: 'org.opent2t.sample.lamp.superpopular',
         power: { 'value': powered },
-        dim: { 'dimmingSetting': scaleBrightnessToDim(brightness), 'range': [0, 100] }
+        dim: { 'dimmingSetting': scaleDeviceBrightnessToTranslatorBrightness(brightness), 'range': [0, 100] }
     };
 }
 
@@ -78,7 +78,7 @@ function translatorSchemaToDeviceSchema(translatorSchema) {
     }
 
     if (!!translatorSchema.dim) {
-        desired_state['brightness'] = scaleDimToBrightness(translatorSchema.dim.dimmingSetting);
+        desired_state['brightness'] = scaleTranslatorBrightnessToDeviceBrightness(translatorSchema.dim.dimmingSetting);
     }
 
     return result;


### PR DESCRIPTION
This is the dimming part of #86. I'm holding off on color for the moment, since the Lamp schema calls for RGB color, while Wink supports several different color formats, and so we will probably need to do some sort of conversion to support that.