### PR TITLE
Update Wink Thermostat translator to map to a fixed set of HVAC modes

### DIFF
--- a/org.opent2t.sample.thermostat.superpopular/com.nest.thermostat/js/thingTranslator.js
+++ b/org.opent2t.sample.thermostat.superpopular/com.nest.thermostat/js/thingTranslator.js
@@ -118,7 +118,7 @@ function translatorSchemaToDeviceSchema(translatorSchema) {
     }
 
     if (translatorSchema.hvacMode) {
-        result['hvac_mode'] = translatorSchema.hvacMode.modes[0];
+        result['hvac_mode'] = translatorHvacModeToDeviceHvacMode(translatorSchema.hvacMode.modes[0]);
     }
 
     return result;

--- a/org.opent2t.sample.thermostat.superpopular/com.nest.thermostat/js/thingTranslator.js
+++ b/org.opent2t.sample.thermostat.superpopular/com.nest.thermostat/js/thingTranslator.js
@@ -15,34 +15,26 @@ function validateArgumentType(arg, argName, expectedType) {
     }
 }
 
-function deviceHvacModeToTranslatorHvacMode(mode) {
-    switch (mode) {
-        case 'cool':
-            return 'coolOnly';
-        case 'heat':
-            return 'heatOnly';
-        case 'heat-cool':
-            return 'auto';
-        case 'off':
-            return 'off';
-    }
+var deviceHvacModeToTranslatorHvacModeMap = {
+    'cool': 'coolOnly',
+    'heat': 'heatOnly',
+    'heat-cool': 'auto',
+    'off': 'off'
+}
 
-    return undefined;
+var translatorHvacModeToDeviceHvacModeMap = {
+    'coolOnly': 'cool',
+    'heatOnly': 'heat',
+    'auto': 'heat-cool',
+    'off': 'off'
+}
+
+function deviceHvacModeToTranslatorHvacMode(mode) {
+    return deviceHvacModeToTranslatorHvacModeMap[mode];
 }
 
 function translatorHvacModeToDeviceHvacMode(mode) {
-    switch (mode) {
-        case 'coolOnly':
-            return 'cool';
-        case 'heatOnly':
-            return 'heat';
-        case 'auto':
-            return 'heat-cool';
-        case 'off':
-            return 'off';
-    }
-
-    return undefined;
+    return translatorHvacModeToDeviceHvacModeMap[mode];
 }
 
 function readHvacMode(deviceSchema) {

--- a/org.opent2t.sample.thermostat.superpopular/com.wink.thermostat/js/tests/test.js
+++ b/org.opent2t.sample.thermostat.superpopular/com.wink.thermostat/js/tests/test.js
@@ -175,3 +175,21 @@ test.serial('PostThermostatResURI_Set_HvacMode', t => {
             console.log('*** response: \n' + JSON.stringify(response, null, 2));
         });
 });
+
+test.serial('PostThermostatResURI_Set_HvacMode_Off_Then_HeatOnly', async t => {
+
+    var value = {};
+    value['hvacMode'] = { 'modes': ['off'] };
+
+    var offResponse = await OpenT2T.invokeMethodAsync(translator, 'org.opent2t.sample.thermostat.superpopular', 'postThermostatResURI', [value]);
+    t.is(offResponse.hvacMode.modes[0], 'off');
+
+    console.log('*** offResponse: \n' + JSON.stringify(offResponse, null, 2));
+
+    value['hvacMode'] = { 'modes': ['heatOnly'] };
+
+    var heatOnlyResponse = await OpenT2T.invokeMethodAsync(translator, 'org.opent2t.sample.thermostat.superpopular', 'postThermostatResURI', [value]);
+    t.is(heatOnlyResponse.hvacMode.modes[0], 'heatOnly');
+
+    console.log('*** heatOnlyresponse: \n' + JSON.stringify(heatOnlyResponse, null, 2));
+});

--- a/org.opent2t.sample.thermostat.superpopular/com.wink.thermostat/js/thingTranslator.js
+++ b/org.opent2t.sample.thermostat.superpopular/com.wink.thermostat/js/thingTranslator.js
@@ -35,30 +35,24 @@ class StateReader {
     }
 }
 
-function deviceHvacModeToTranslatorHvacMode(mode) {
-    switch (mode) {
-        case 'cool_only':
-            return 'coolOnly';
-        case 'heat_only':
-            return 'heatOnly';
-        case 'auto':
-            return 'auto';
-    }
+var deviceHvacModeToTranslatorHvacModeMap = {
+    'cool_only': 'coolOnly',
+    'heat_only': 'heatOnly',
+    'auto': 'auto'
+}
 
-    return undefined;
+var translatorHvacModeToDeviceHvacModeMap = {
+    'coolOnly': 'cool_only',
+    'heatOnly': 'heat_only',
+    'auto': 'auto'
+}
+
+function deviceHvacModeToTranslatorHvacMode(mode) {
+    return deviceHvacModeToTranslatorHvacModeMap[mode];
 }
 
 function translatorHvacModeToDeviceHvacMode(mode) {
-    switch (mode) {
-        case 'coolOnly':
-            return 'cool_only';
-        case 'heatOnly':
-            return 'heat_only';
-        case 'auto':
-            return 'auto';
-    }
-
-    return undefined;
+    return translatorHvacModeToDeviceHvacModeMap[mode];
 }
 
 function readHvacMode(stateReader) {

--- a/org.opent2t.sample.thermostat.superpopular/org.opent2t.sample.thermostat.superpopular.json
+++ b/org.opent2t.sample.thermostat.superpopular/org.opent2t.sample.thermostat.superpopular.json
@@ -49,7 +49,7 @@
         },
         "hvacMode": {
           "$ref": "oic.r.mode.json#/definitions/oic.r.mode",
-          "description": "Active & Supported heating/Cooling modes supported the device."
+          "description": "Active & Supported heating/Cooling modes supported the device. Should be one of ['coolOnly', 'heatOnly', 'auto', 'off']"
         },
         "heatingFuelSource": {
           "type": "string",


### PR DESCRIPTION
-This makes it so HVAC modes aren't defined by the translator, rather each translator is expected to map to a fixed set of possible values
-Added support for an 'off' HVAC mode, which uses Wink's 'powered' property underneath