### PR TITLE
Updating NPM package versions to match published

### DIFF
--- a/org.opent2t.sample.binaryswitch.superpopular/com.wink.binaryswitch/js/package.json
+++ b/org.opent2t.sample.binaryswitch.superpopular/com.wink.binaryswitch/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opent2t-translator-com-wink-binaryswitch",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Wink Binary Switch",
   "homepage": "http://opentranslatorstothings.org",
   "repository": {

--- a/org.opent2t.sample.hub.superpopular/com.wink.hub/js/package.json
+++ b/org.opent2t.sample.hub.superpopular/com.wink.hub/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opent2t-translator-com-wink-hub",
-  "version": "1.0.3",
+  "version": "1.0.5",
   "description": "Wink Hub",
   "license": "MIT",
   "main": "thingTranslator.js",

--- a/org.opent2t.sample.lamp.superpopular/com.wink.lightbulb/js/package.json
+++ b/org.opent2t.sample.lamp.superpopular/com.wink.lightbulb/js/package.json
@@ -1,6 +1,6 @@
 {
     "name": "opent2t-translator-com-wink-lightbulb",
-    "version": "0.1.6",
+    "version": "0.1.7",
     "description": "Wink Light Bulb",
     "homepage": "http://opentranslatorstothings.org",
     "repository": {

--- a/org.opent2t.sample.thermostat.superpopular/com.wink.thermostat/js/package.json
+++ b/org.opent2t.sample.thermostat.superpopular/com.wink.thermostat/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opent2t-translator-com-wink-thermostat",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Wink Thermostat",
   "homepage": "http://opentranslatorstothings.org",
   "repository": {


### PR DESCRIPTION
Incrementing patch version by one (two in the case of the hub, looks like it was missed once).