### PR TITLE
Fixing invalid RAML by adding subscription schema

### DIFF
--- a/org.opent2t.sample.binaryswitch.superpopular/org.opent2t.sample.binaryswitch.superpopular.raml
+++ b/org.opent2t.sample.binaryswitch.superpopular/org.opent2t.sample.binaryswitch.superpopular.raml
@@ -4,6 +4,15 @@ version: v1.0
 
 schemas:
   - Switch: !include org.opent2t.sample.binaryswitch.superpopular.json
+  - Subscription: |
+      {
+        "type": "object",
+        "properties": {
+          "callbackUrl": { "type": "string" },
+          "expiration": { "type": "number" },
+          "response": { "type": "string"}
+        }
+      }
 
 traits:
   - interface:
@@ -69,25 +78,28 @@ traits:
   is: [ interface ]
     
   post:
-    description: Creates or refreshes a subscription to this binaryswitch.  This method should be called twice, first with
-    a callback URL (verificationRequest will be ignored), and the second time with the parameters of an http GET to the
-    callback Url server for verification of the subscription (in which case callback Url will be ignored). The second call
-    will construct a response that should be returned to the notifications server.
+    description: |
+        Creates or refreshes a subscription to this binary switch.  This method should be called twice, first with
+        a callback URL (verificationRequest will be ignored), and the second time with the parameters of an http GET to the
+        callback Url server for verification of the subscription (in which case callback Url will be ignored). The second call
+        will construct a response that should be returned to the notifications server.
     body:
       application/json:
+        schema: Subscription
         example: |
           {
-            "callbackUrl": "http://myserver.com?uuid=534cfd&schema=org.opent2t.sample.binaryswitch.superpopular&deviceId=123456",
-            "verificationRequest": { ... }
+            "callbackUrl": "http://myserver.com",
           }    
     responses:
        200:
         body:
           application/json:
+            schema: Subscription
             example: |
                 {
-                    "expiration": "123456678",
-                    "response": { "plain text response" }
+                  "callbackUrl":"http://myserver.com",
+                  "expiration": "123456678",
+                  "response": { "plain text response" }
                 }
        400:
           body:
@@ -102,12 +114,14 @@ traits:
     description: Unsubscribes to notifications to a callback Url
     body:
       application/json:
+        schema: Subscription
         example: |
           {
-            "callbackUrl": "http://myserver.com?uuid=534cfd&schema=org.opent2t.sample.binaryswitch.superpopular&deviceId=123456",
+            "callbackUrl": "http://myserver.com",
           } 
     responses:
       200:
         body:
           application/json:
-          example: {}              
+          example: {}
+                

--- a/org.opent2t.sample.lamp.superpopular/org.opent2t.sample.lamp.superpopular.raml
+++ b/org.opent2t.sample.lamp.superpopular/org.opent2t.sample.lamp.superpopular.raml
@@ -4,6 +4,15 @@ version: v1.0
 
 schemas:
   - Lamp: !include org.opent2t.sample.lamp.superpopular.json
+  - Subscription: |
+      {
+        "type": "object",
+        "properties": {
+          "callbackUrl": { "type": "string" },
+          "expiration": { "type": "number" },
+          "response": { "type": "string"}
+        }
+      }
 
 traits:
   - interface:
@@ -83,25 +92,28 @@ traits:
   is: [ interface ]
     
   post:
-    description: Creates or refreshes a subscription to this lamp.  This method should be called twice, first with
-    a callback URL (verificationRequest will be ignored), and the second time with the parameters of an http GET to the
-    callback Url server for verification of the subscription (in which case callback Url will be ignored). The second call
-    will construct a response that should be returned to the notifications server.
+    description: |
+        Creates or refreshes a subscription to this lamp.  This method should be called twice, first with
+        a callback URL (verificationRequest will be ignored), and the second time with the parameters of an http GET to the
+        callback Url server for verification of the subscription (in which case callback Url will be ignored). The second call
+        will construct a response that should be returned to the notifications server.
     body:
       application/json:
+        schema: Subscription
         example: |
           {
-            "callbackUrl": "http://myserver.com?uuid=534cfd&schema=org.opent2t.sample.lamp.superpopular&deviceId=123456",
-            "verificationRequest": { ... }
+            "callbackUrl": "http://myserver.com",
           }    
     responses:
        200:
         body:
           application/json:
+            schema: Subscription
             example: |
                 {
-                    "expiration": "123456678",
-                    "response": { "plain text response" }
+                  "callbackUrl":"http://myserver.com",
+                  "expiration": "123456678",
+                  "response": { "plain text response" }
                 }
        400:
           body:
@@ -116,9 +128,10 @@ traits:
     description: Unsubscribes to notifications to a callback Url
     body:
       application/json:
+        schema: Subscription
         example: |
           {
-            "callbackUrl": "http://myserver.com?uuid=534cfd&schema=org.opent2t.sample.lamp.superpopular&deviceId=123456",
+            "callbackUrl": "http://myserver.com",
           } 
     responses:
       200:

--- a/org.opent2t.sample.thermostat.superpopular/org.opent2t.sample.thermostat.superpopular.raml
+++ b/org.opent2t.sample.thermostat.superpopular/org.opent2t.sample.thermostat.superpopular.raml
@@ -4,6 +4,15 @@ version: v1.0
 
 schemas:
   - Thermostat: !include org.opent2t.sample.thermostat.superpopular.json
+  - Subscription: |
+      {
+        "type": "object",
+        "properties": {
+          "callbackUrl": { "type": "string" },
+          "expiration": { "type": "number" },
+          "response": { "type": "string"}
+        }
+      }
 
 traits:
   - interface:
@@ -81,25 +90,28 @@ traits:
   is: [ interface ]
     
   post:
-    description: Creates or refreshes a subscription to this Thermostat.  This method should be called twice, first with
-    a callback URL (verificationRequest will be ignored), and the second time with the parameters of an http GET to the
-    callback Url server for verification of the subscription (in which case callback Url will be ignored). The second call
-    will construct a response that should be returned to the notifications server.
+    description: |
+        Creates or refreshes a subscription to this Thermostat.  This method should be called twice, first with
+        a callback URL (verificationRequest will be ignored), and the second time with the parameters of an http GET to the
+        callback Url server for verification of the subscription (in which case callback Url will be ignored). The second call
+        will construct a response that should be returned to the notifications server.
     body:
       application/json:
+        schema: Subscription
         example: |
           {
-            "callbackUrl": "http://myserver.com?uuid=534cfd&schema=org.opent2t.sample.thermostat.superpopular&deviceId=123456",
-            "verificationRequest": { ... }
+            "callbackUrl": "http://myserver.com",
           }    
     responses:
        200:
         body:
           application/json:
+            schema: Subscription
             example: |
                 {
-                    "expiration": "123456678",
-                    "response": { "plain text response" }
+                  "callbackUrl":"http://myserver.com",
+                  "expiration": "123456678",
+                  "response": { "plain text response" }
                 }
        400:
           body:
@@ -114,9 +126,10 @@ traits:
     description: Unsubscribes to notifications to a callback Url
     body:
       application/json:
+        schema: Subscription
         example: |
           {
-            "callbackUrl": "http://myserver.com?uuid=534cfd&schema=org.opent2t.sample.thermostat.superpopular&deviceId=123456",
+            "callbackUrl": "http://myserver.com",
           } 
     responses:
       200:


### PR DESCRIPTION
Invalid RAML causes OpenT2T to choke when calling getSchemaAsync(), need to have subscription schemas.