### PR TITLE
Add expiration to Wink authorization refresh

### DIFF
--- a/org.opent2t.sample.hub.superpopular/com.wink.hub/js/common.js
+++ b/org.opent2t.sample.hub.superpopular/com.wink.hub/js/common.js
@@ -8,13 +8,23 @@ class accessTokenInfo {
             accessToken,
             refreshToken,
             tokenType, // ex: 'bearer'
-            scopes // ex: 'full_access'
+            scopes, // ex: 'full_access'
+            expiration // Timestamp for expiration (seconds)
         )
     {
         this.accessToken = accessToken;
         this.refreshToken = refreshToken;
         this.tokenType = tokenType;
         this.scopes = scopes;
+        
+        if (expiration === undefined) {
+            // If no expiration is provided, then set the expiration for the token token
+            // 24 hours (86400 seconds) into the future.
+            // getTime returns milliseconds, so we first convert to seconds.
+            this.expiration = Math.floor(new Date().getTime() / 1000) + 86400;
+        } else {
+            this.times = expiration;
+        }
     }
 }
 


### PR DESCRIPTION
Uses a default 24 hours.