### PR TITLE
Passing right context to callbacks to be able to use instance variables

### DIFF
--- a/Helpers/opent2t-translator-helper-nest/js/index.js
+++ b/Helpers/opent2t-translator-helper-nest/js/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var request = require('request-promise');
+var OpenT2TLogger = require('opent2t').Logger;
 
 // Nest developer endpoint as documented here: http:/developers.nest.com/
 var apiEndpoint = 'https://developer-api.nest.com';
@@ -11,10 +12,13 @@ var bearerToken;
 class NestHelper {
 
     // Init Helper: Sets the initial parameters to build our target endpoint
-    constructor(accessToken) {
+    constructor(accessToken, logLevel = "info") {
+        this.ConsoleLogger = new OpenT2TLogger(logLevel);
+        this.ConsoleLogger.info("Initilizing Nest helper");
+        
         bearerToken = accessToken;
-
-        console.log('Initialized Nest Helper.');
+        
+        this.ConsoleLogger.info('Initialized Nest Helper.');
     }
 
     // Gets device details (all fields), response formatted per http:/developers.nest.com/

--- a/Helpers/opent2t-translator-helper-nest/js/package.json
+++ b/Helpers/opent2t-translator-helper-nest/js/package.json
@@ -4,7 +4,8 @@
     "description": "",
     "dependencies": {
         "request": "^2.34",
-        "request-promise": "4.1.1"
+        "request-promise": "4.1.1",
+        "opent2t": "^1.0.4"
     },
     "devDependencies": {},
     "author": "",

--- a/Helpers/opent2t-translator-helper-wink/js/index.js
+++ b/Helpers/opent2t-translator-helper-wink/js/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var request = require('request-promise');
+var OpenT2TLogger = require('opent2t').Logger;
 
 // wink v2 api endpoint as documented here: http://docs.winkapiv2.apiary.io/
 var apiEndpoint = 'https://api.wink.com';
@@ -11,10 +12,11 @@ var bearerToken;
 class WinkHelper {
 
     // Init Helper: Sets the initial parameters to build our target endpoint
-    constructor(accessToken) {
+    constructor(accessToken, logLevel = "info") {
+        this.ConsoleLogger = new OpenT2TLogger(logLevel);
+        this.ConsoleLogger.info("Initilizing WINK helper");
         bearerToken = accessToken;
-
-        console.log('Initialized Wink Helper.');
+        this.ConsoleLogger.info('Initialized Wink Helper.');
     }
 
     // Gets device details (all fields), response formatted per http://docs.winkapiv2.apiary.io/

--- a/Helpers/opent2t-translator-helper-wink/js/package.json
+++ b/Helpers/opent2t-translator-helper-wink/js/package.json
@@ -4,7 +4,8 @@
     "description": "",
     "dependencies": {
         "request": "^2.34",
-        "request-promise": "4.1.1"
+        "request-promise": "4.1.1",
+        "opent2t": "^1.0.4"
     },
     "devDependencies": {},
     "author": "",

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ existing version.)
 
 ```
 cd ..
-git clone https://github.com/opent2t/cli
+git clone https://github.com/opent2t-cli
 npm install
 cd ../translators
 ```
@@ -86,7 +86,7 @@ published. Note the last parameter is a simple name of a translator,
 not a directory path, which would include a schema name.
 
 ```
-node ../cli/pack-translator.js com.wink.thermostat
+node ../opent2t-cli/pack-translator.js com.wink.thermostat
 ```
 
 4. Edit the package.json to include directories for referenced schemas in the

--- a/org.opent2t.sample.binaryswitch.superpopular/com.insteon.binaryswitch/js/thingTranslator.js
+++ b/org.opent2t.sample.binaryswitch.superpopular/com.insteon.binaryswitch/js/thingTranslator.js
@@ -2,7 +2,7 @@
 
 var OpenT2TError = require('opent2t').OpenT2TError;
 var OpenT2TConstants = require('opent2t').OpenT2TConstants;
-
+var OpenT2TLogger = require('opent2t').Logger;
 var crypto = require('crypto');
 
 // This code uses ES2015 syntax that requires at least Node.js v4.
@@ -138,15 +138,17 @@ const switchDeviceDi = "f9604075-1a64-498b-ae9b-7436a63721ba";
 // This translator class implements the 'org.opent2t.sample.binaryswitch.superpopular' interface.
 class Translator {
 
-    constructor(deviceInfo) {
-        console.log('Insteon Binary Switch initializing...');
+    constructor(deviceInfo, logLevel = "info") {
+        this.ConsoleLogger = new OpenT2TLogger(logLevel);
+
+        this.ConsoleLogger.info('Insteon Binary Switch initializing...');
 
         validateArgumentType(deviceInfo, "deviceInfo", "object");
         
         this.controlId = deviceInfo.deviceInfo.opent2t.controlId;
         this.insteonHub = deviceInfo.hub;
 
-        console.log('Insteon Binary Switch initializing...Done');
+        this.ConsoleLogger.info('Insteon Binary Switch initializing...Done');
     }
 
     /**

--- a/org.opent2t.sample.binaryswitch.superpopular/com.smartthings.binaryswitch/js/thingTranslator.js
+++ b/org.opent2t.sample.binaryswitch.superpopular/com.smartthings.binaryswitch/js/thingTranslator.js
@@ -2,6 +2,7 @@
 
 var OpenT2TError = require('opent2t').OpenT2TError;
 var OpenT2TConstants = require('opent2t').OpenT2TConstants;
+var OpenT2TLogger = require('opent2t').Logger;
 
 // This code uses ES2015 syntax that requires at least Node.js v4.
 // For Node.js ES2015 support details, reference http://node.green/
@@ -106,15 +107,17 @@ const switchDeviceDi = "d455d979-d1f9-430a-8a15-61c432eda4a2";
 // This translator class implements the 'org.opent2t.sample.binaryswitch.superpopular' interface.
 class Translator {
 
-    constructor(deviceInfo) {
-        console.log('SmartThings Binary Switch initializing...');
+    constructor(deviceInfo, logLevel = "info") {
+        this.ConsoleLogger = new OpenT2TError(logLevel);
+
+        this.ConsoleLogger.info('SmartThings Binary Switch initializing...');
 
         validateArgumentType(deviceInfo, "deviceInfo", "object");
         
         this.controlId = deviceInfo.deviceInfo.opent2t.controlId;
         this.smartThingsHub = deviceInfo.hub;
 
-        console.log('SmartThings Binary Switch initializing...Done');
+        this.ConsoleLogger.info('SmartThings Binary Switch initializing...Done');
     }
 
     /**

--- a/org.opent2t.sample.binaryswitch.superpopular/com.smartthings.binaryswitch/js/thingTranslator.js
+++ b/org.opent2t.sample.binaryswitch.superpopular/com.smartthings.binaryswitch/js/thingTranslator.js
@@ -108,7 +108,7 @@ const switchDeviceDi = "d455d979-d1f9-430a-8a15-61c432eda4a2";
 class Translator {
 
     constructor(deviceInfo, logLevel = "info") {
-        this.ConsoleLogger = new OpenT2TError(logLevel);
+        this.ConsoleLogger = new OpenT2TLogger(logLevel);
 
         this.ConsoleLogger.info('SmartThings Binary Switch initializing...');
 

--- a/org.opent2t.sample.hub.superpopular/com.insteon.hub/js/thingTranslator.js
+++ b/org.opent2t.sample.hub.superpopular/com.insteon.hub/js/thingTranslator.js
@@ -120,7 +120,7 @@ class Translator {
                                                     });
                                             }).catch((err) => {
                                                 // Being logged in HubController already
-                                                return Promise.resolve(undefined);
+                                                return Promise.reject(err);
                                             });
                                         
                                     }).catch((err) => { 

--- a/org.opent2t.sample.hub.superpopular/com.insteon.hub/js/thingTranslator.js
+++ b/org.opent2t.sample.hub.superpopular/com.insteon.hub/js/thingTranslator.js
@@ -119,7 +119,7 @@ class Translator {
                                                         return platformResponse;
                                                     });
                                             }).catch((err) => {
-                                                console.log('warning: OpenT2T.createTranslatorAsync error for ' + opent2tInfo.translator + ' - ' + JSON.stringify(err, null, 2));
+                                                // Being logged in HubController already
                                                 return Promise.resolve(undefined);
                                             });
                                         
@@ -436,7 +436,9 @@ class Translator {
                             }
                     }
                 })
-                .catch((err) => { console.log(err); });
+                .catch((err) => { 
+                    Promise.reject(err); 
+                });
             });
         }
     

--- a/org.opent2t.sample.hub.superpopular/com.nest.hub/js/thingTranslator.js
+++ b/org.opent2t.sample.hub.superpopular/com.nest.hub/js/thingTranslator.js
@@ -172,7 +172,8 @@ class Translator {
             var endInd = str.lastIndexOf('}');
             var errorMsg = JSON.parse(str.substring(startInd, endInd + 1));
             this.ConsoleLogger.error("Ran into error in putDeviceDetailsAsync: ", errorMsg.error);
-            return Promise.reject(errorMsg.error);        });
+            return Promise.reject(errorMsg.error);        
+        }.bind(this));
     }
     
     /**
@@ -202,7 +203,8 @@ class Translator {
             var endInd = str.lastIndexOf('}');
             var errorMsg = JSON.parse(str.substring(startInd, endInd + 1));
             this.ConsoleLogger.error("Ran into error in setAwayMode: ", errorMsg.error);
-            return Promise.reject(errorMsg.error);        });
+            return Promise.reject(errorMsg.error);        
+        }.bind(this));
     }
 }
 

--- a/org.opent2t.sample.hub.superpopular/com.smartthings.hub/js/thingTranslator.js
+++ b/org.opent2t.sample.hub.superpopular/com.smartthings.hub/js/thingTranslator.js
@@ -263,7 +263,7 @@ class Translator {
                 } else {
                     return JSON.parse(body);
                 }                
-            });
+            }.bind(this));
     }
 }
 

--- a/org.opent2t.sample.hub.superpopular/com.smartthings.hub/js/thingTranslator.js
+++ b/org.opent2t.sample.hub.superpopular/com.smartthings.hub/js/thingTranslator.js
@@ -4,7 +4,6 @@
 "use strict";
 var request = require('request-promise');
 var OpenT2T = require('opent2t').OpenT2T;
-var OpenT2TError = require('opent2t').OpenT2TError;
 var OpenT2TLogger = require('opent2t').Logger;
 /**
 * This translator class implements the "Hub" interface.

--- a/org.opent2t.sample.hub.superpopular/com.wink.hub/js/thingTranslator.js
+++ b/org.opent2t.sample.hub.superpopular/com.wink.hub/js/thingTranslator.js
@@ -454,7 +454,7 @@ class Translator {
                 this.ConsoleLogger.error(`Request failed to: ${options.method} - ${options.url}`); 
                 request.reject(err);
                 return;
-            });
+            }).bind(this); //Pass in the context via bind() to use instance variables
             
     }
 

--- a/org.opent2t.sample.lamp.superpopular/com.insteon.lightbulb/js/thingTranslator.js
+++ b/org.opent2t.sample.lamp.superpopular/com.insteon.lightbulb/js/thingTranslator.js
@@ -173,14 +173,14 @@ class Translator {
 
     constructor(deviceInfo, logLevel = "info") {
         this.ConsoleLogger = new OpenT2TLogger(logLevel);
-        this.ConsoleLogger.verbose('Insteon Lightbulb initializing...');
+        this.ConsoleLogger.info('Insteon Lightbulb initializing...');
 
         validateArgumentType(deviceInfo, "deviceInfo", "object");
 
         this.controlId = deviceInfo.deviceInfo.opent2t.controlId;
         this.insteonHub = deviceInfo.hub;
 
-        this.ConsoleLogger.verbose('Insteon Lightbulb initializing...Done');
+        this.ConsoleLogger.info('Insteon Lightbulb initializing...Done');
     }
 
     /**

--- a/org.opent2t.sample.lamp.superpopular/com.smartthings.lightbulb/js/thingTranslator.js
+++ b/org.opent2t.sample.lamp.superpopular/com.smartthings.lightbulb/js/thingTranslator.js
@@ -283,14 +283,14 @@ class Translator {
         
     constructor(deviceInfo, logLevel = "info") {
        this.ConsoleLogger = new OpenT2TLogger(logLevel);
-        this.ConsoleLogger.verbose('SmartThings Lightbulb initializing...');
+        this.ConsoleLogger.info('SmartThings Lightbulb initializing...');
 
         validateArgumentType(deviceInfo, "deviceInfo", "object");
         
         this.controlId = deviceInfo.deviceInfo.opent2t.controlId;
         this.smartThingsHub = deviceInfo.hub;
 
-        this.ConsoleLogger.verbose('SmartThings Lightbulb initializing...Done');
+        this.ConsoleLogger.info('SmartThings Lightbulb initializing...Done');
     }
 
     /**

--- a/org.opent2t.sample.lamp.superpopular/com.wink.lightbulb/js/thingTranslator.js
+++ b/org.opent2t.sample.lamp.superpopular/com.wink.lightbulb/js/thingTranslator.js
@@ -191,7 +191,7 @@ class Translator {
 
     constructor(deviceInfo, logLevel = "info") {
         this.ConsoleLogger = new OpenT2TLogger(logLevel); 
-        this.ConsoleLogger.verbose('Wink Lightbulb initializing...');
+        this.ConsoleLogger.info('Wink Lightbulb initializing...');
 
         validateArgumentType(deviceInfo, "deviceInfo", "object");
        
@@ -199,7 +199,7 @@ class Translator {
         this.winkHub = deviceInfo.hub;
         this.deviceType = 'light_bulbs';
 
-        this.ConsoleLogger.verbose('Wink Lightbulb initializing...Done');
+        this.ConsoleLogger.info('Wink Lightbulb initializing...Done');
     }
 
     /**

--- a/org.opent2t.sample.thermostat.superpopular/com.insteon.thermostat/js/thingTranslator.js
+++ b/org.opent2t.sample.thermostat.superpopular/com.insteon.thermostat/js/thingTranslator.js
@@ -276,14 +276,14 @@ class Translator {
 
     constructor(deviceInfo, logLevel = "info") {
         this.ConsoleLogger = new OpenT2TLogger(logLevel);
-        this.ConsoleLogger.verbose('Insteon Thermostat initializing...');
+        this.ConsoleLogger.info('Insteon Thermostat initializing...');
 
         validateArgumentType(deviceInfo, "deviceInfo", "object");
 
         this.controlId = deviceInfo.deviceInfo.opent2t.controlId;
         this.insteonHub = deviceInfo.hub;
 
-        this.ConsoleLogger.verbose('Insteon Thermostat initializing...Done');
+        this.ConsoleLogger.info('Insteon Thermostat initializing...Done');
     }
 
     /**

--- a/org.opent2t.sample.thermostat.superpopular/com.nest.thermostat/js/thingTranslator.js
+++ b/org.opent2t.sample.thermostat.superpopular/com.nest.thermostat/js/thingTranslator.js
@@ -283,7 +283,7 @@ class Translator {
 
     constructor(deviceInfo, logLevel = "info") {
         this.ConsoleLogger = new OpenT2TLogger(logLevel);
-        this.ConsoleLogger.verbose('Nest Thermostat initializing...');
+        this.ConsoleLogger.info('Nest Thermostat initializing...');
 
         validateArgumentType(deviceInfo, "deviceInfo", "object");
         this.controlId = deviceInfo.deviceInfo.opent2t.controlId;
@@ -291,7 +291,7 @@ class Translator {
         this.nestHub = deviceInfo.hub;
         this.deviceType = 'thermostats';
 
-        this.ConsoleLogger.verbose('Nest Thermostat initializing...Done');
+        this.ConsoleLogger.info('Nest Thermostat initializing...Done');
     }
 
     /**

--- a/org.opent2t.sample.thermostat.superpopular/com.smartthings.thermostat/js/thingTranslator.js
+++ b/org.opent2t.sample.thermostat.superpopular/com.smartthings.thermostat/js/thingTranslator.js
@@ -236,14 +236,14 @@ class Translator {
      
     constructor(deviceInfo, logLevel = "info") {
         this.ConsoleLogger = new OpenT2TLogger(logLevel);
-        this.ConsoleLogger.verbose('SmartThings Thermostat initializing...');
+        this.ConsoleLogger.info('SmartThings Thermostat initializing...');
 
         validateArgumentType(deviceInfo, "deviceInfo", "object");
 
         this.controlId = deviceInfo.deviceInfo.opent2t.controlId;
         this.smartThingsHub = deviceInfo.hub;
 
-        this.ConsoleLogger.verbose('SmartThings Thermostat initializing...Done');
+        this.ConsoleLogger.info('SmartThings Thermostat initializing...Done');
     }
     
     /**

--- a/org.opent2t.sample.thermostat.superpopular/com.wink.thermostat/js/thingTranslator.js
+++ b/org.opent2t.sample.thermostat.superpopular/com.wink.thermostat/js/thingTranslator.js
@@ -279,7 +279,7 @@ class Translator {
 
     constructor(deviceInfo, logLevel = "info") {
         this.ConsoleLogger = new OpenT2TLogger(logLevel);
-        this.ConsoleLogger.verbose('Initializing device.');
+        this.ConsoleLogger.info('Initializing device.');
 
         validateArgumentType(deviceInfo, "deviceInfo", "object");
 
@@ -287,7 +287,7 @@ class Translator {
         this.winkHub = deviceInfo.hub;
         this.deviceType = 'thermostats';
 
-        this.ConsoleLogger.verbose('Wink Thermostat Translator initialized.');
+        this.ConsoleLogger.info('Wink Thermostat Translator initialized.');
     }
 
     /**


### PR DESCRIPTION
- Update to NEST translators to call to bind() to pass in the right context to callbacks. 
- Updating binary switch translators for Insteon/NEST still using console.log.
- Minor update to Readme around pack-translator location