### PR TITLE
Dynamic URL support for getUserPermissions

### DIFF
--- a/org.opent2t.sample.hub.superpopular/com.nest.hub/js/manifest.xml
+++ b/org.opent2t.sample.hub.superpopular/com.nest.hub/js/manifest.xml
@@ -24,6 +24,10 @@
         <arg name="url" />
         <description language="en">https://home.nest.com/login/oauth2?client_id={client_id}&amp;state={state}</description>
       </flow>
+      <flow>
+        <arg name="method" />
+        <description language="en">getUserVerificationUri</description>
+      </flow>
     </onboardflow>
   </onboarding>
 </manifest>

--- a/org.opent2t.sample.hub.superpopular/com.smartthings.hub/js/manifest.xml
+++ b/org.opent2t.sample.hub.superpopular/com.smartthings.hub/js/manifest.xml
@@ -26,8 +26,8 @@
     </onboardflow>
     <onboardflow name="askUserPermission">
       <flow>
-        <arg name="url" />
-        <description language="en">https://graph.api.smartthings.com/oauth/authorize?response_type=code&amp;client_id={client_id}&amp;redirect_uri={redirect_url}&amp;scope=app</description>
+        <arg name="method" />
+        <description language="en">getUserVerificationUri</description>
       </flow>
     </onboardflow>
   </onboarding>

--- a/org.opent2t.sample.hub.superpopular/com.smartthings.hub/js/manifest.xml
+++ b/org.opent2t.sample.hub.superpopular/com.smartthings.hub/js/manifest.xml
@@ -26,6 +26,10 @@
     </onboardflow>
     <onboardflow name="askUserPermission">
       <flow>
+        <arg name="url" />
+        <description language="en">https://graph.api.smartthings.com/oauth/authorize?response_type=code&amp;client_id={client_id}&amp;redirect_uri={redirect_url}&amp;scope=app</description>
+      </flow>
+      <flow>
         <arg name="method" />
         <description language="en">getUserVerificationUri</description>
       </flow>


### PR DESCRIPTION
Changes the SmartThings hub to use dynamic URL generation.  This frees up the caller from having to perform string replacement, and opens the door for dynamic URLs that come from other sources.

Nest also uses an oauth2 verification URI, but I've left it as is in order to allow both the old and new versions to co-exist in the CLI.