### PR TITLE
Add a check for max dimming value ST lights.

### DIFF
--- a/org.opent2t.sample.lamp.superpopular/com.smartthings.lightbulb/js/thingTranslator.js
+++ b/org.opent2t.sample.lamp.superpopular/com.smartthings.lightbulb/js/thingTranslator.js
@@ -207,6 +207,7 @@ function providerSchemaToPlatformSchema(providerSchema, expand) {
 
         dim.id = 'dim';
         dim.dimmingSetting = providerSchema['attributes'].level;
+        if (dim.dimmingSetting > 100 ) dim.dimmingSetting = 100;
         dim.range = [0, 100];
         
         if (supportColour) {


### PR DESCRIPTION
A fix for #232 :  The root cause of the issue seems to be between AEOTec and SmartThings. When we turn the AEOTec off and on, the switch level sometimes (over 50% of time) showed up as 255% then to 99% (which is the max level in AEOTec switch) after a few seconds. Therefore, if we query for device status during this time frame, we will get dimming level of 255%.  This PR includes a workaround of this bug by placing a cap on the maximum brightness as light bulb can have.  According to SmartThings documentation, the switch level of a SmartThings device is usually from 0 to 100 in percent.