### PR TITLE
Hot fix for autoheat, autocool support in smartthings

### DIFF
--- a/org.opent2t.sample.thermostat.superpopular/com.smartthings.thermostat/js/package.json
+++ b/org.opent2t.sample.thermostat.superpopular/com.smartthings.thermostat/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opent2t-translator-com-smartthings-thermostat",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "SmartThings Thermostat",
   "homepage": "http://opentranslatorstothings.org",
   "repository": {

--- a/org.opent2t.sample.thermostat.superpopular/com.smartthings.thermostat/js/thingTranslator.js
+++ b/org.opent2t.sample.thermostat.superpopular/com.smartthings.thermostat/js/thingTranslator.js
@@ -448,7 +448,6 @@ class Translator {
                             Object.assign(response, putPayload.response);
                             var schema = providerSchemaToPlatformSchema(response, true);
                             // from logs: autocool does not allow changing thermostat setpoint - we'll do target high/low for this case
-                            console.log(response.thermostatMode);
                             if (response.thermostatMode === 'auto' ||
                                 response.thermostatMode === 'autoheat' ||
                                 response.thermostatMode === 'autocool') {

--- a/org.opent2t.sample.thermostat.superpopular/com.smartthings.thermostat/js/thingTranslator.js
+++ b/org.opent2t.sample.thermostat.superpopular/com.smartthings.thermostat/js/thingTranslator.js
@@ -447,7 +447,11 @@ class Translator {
                         return this.smartThingsHub.putDeviceDetailsAsync(this.endpointUri, this.controlId, putPayload.command).then((response) => {
                             Object.assign(response, putPayload.response);
                             var schema = providerSchemaToPlatformSchema(response, true);
-                            if (response.thermostatMode === 'auto') {
+                            // from logs: autocool does not allow changing thermostat setpoint - we'll do target high/low for this case
+                            console.log(response.thermostatMode);
+                            if (response.thermostatMode === 'auto' ||
+                                response.thermostatMode === 'autoheat' ||
+                                response.thermostatMode === 'autocool') {
                                 var low = findResource(schema, di, 'targetTemperatureLow');
                                 var high = findResource(schema, di, 'targetTemperatureHigh');
                                 var hvacMode = findResource(schema, di, 'hvacMode');

--- a/org.opent2t.sample.thermostat.superpopular/com.smartthings.thermostat/js/thingTranslator.js
+++ b/org.opent2t.sample.thermostat.superpopular/com.smartthings.thermostat/js/thingTranslator.js
@@ -598,7 +598,9 @@ class Translator {
                     if (attributes.thermostatMode === 'off') {
                         throw new OpenT2TError(444, "SmartThings thermostat is off.");
                     }
-                    if (attributes.thermostatMode === 'auto') {
+                    if (attributes.thermostatMode === 'auto' ||
+                        response.thermostatMode === 'autoheat' ||
+                        response.thermostatMode === 'autocool') {
                         return getTargetTemperatureRange(resourceSchema, attributes);
                     } else {
                         return getTargetTemperature(resourceSchema, attributes);

--- a/org.opent2t.sample.thermostat.superpopular/com.smartthings.thermostat/js/thingTranslator.js
+++ b/org.opent2t.sample.thermostat.superpopular/com.smartthings.thermostat/js/thingTranslator.js
@@ -599,8 +599,8 @@ class Translator {
                         throw new OpenT2TError(444, "SmartThings thermostat is off.");
                     }
                     if (attributes.thermostatMode === 'auto' ||
-                        response.thermostatMode === 'autoheat' ||
-                        response.thermostatMode === 'autocool') {
+                        attributes.thermostatMode === 'autoheat' ||
+                        attributes.thermostatMode === 'autocool') {
                         return getTargetTemperatureRange(resourceSchema, attributes);
                     } else {
                         return getTargetTemperature(resourceSchema, attributes);


### PR DESCRIPTION
Logs show users have thermostats with an 'autocool' or 'autoheat' mode, we currently set the wrong attribute for thermostats in this mode, they need to be treated like 'auto' mode.